### PR TITLE
Removal of prerelease NuGet dependency and bug fix

### DIFF
--- a/Src/Xeeny.Sockets/Xeeny.Sockets.csproj
+++ b/Src/Xeeny.Sockets/Xeeny.Sockets.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="System.Buffers" Version="4.4.0" />
-    <PackageReference Include="System.Memory" Version="4.4.0-preview1-25305-02" />
   </ItemGroup>
 
 </Project>

--- a/Src/Xeeny.Sockets/Xeeny.Sockets.csproj
+++ b/Src/Xeeny.Sockets/Xeeny.Sockets.csproj
@@ -13,6 +13,9 @@
     <PackageIconUrl>http://icons.iconarchive.com/icons/kyo-tux/delikate/64/Network-icon.png</PackageIconUrl>
     <PackageTags>C# csharp .net standard dotnetstandard duplex services cross-platform multiple-transport tcp udp framework xamarin</PackageTags>
     <PackageReleaseNotes>first release</PackageReleaseNotes>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Src/Xeeny/Api/Server/ServiceHostBuilder.cs
+++ b/Src/Xeeny/Api/Server/ServiceHostBuilder.cs
@@ -39,10 +39,9 @@ namespace Xeeny.Api.Server
         {
             Validate();
 
-            var host = new ServiceHost<TService>(
-                Listeners, 
-                InstanceMode,
-                Serializer, CallbackType, LoggerFactory);
+            var host = SingletonInstance == null
+                ? new ServiceHost<TService>(Listeners, InstanceMode, Serializer, CallbackType, LoggerFactory)
+                : new ServiceHost<TService>(Listeners, SingletonInstance, Serializer, CallbackType, LoggerFactory);
 
             return host;
         }

--- a/Src/Xeeny/Xeeny.csproj
+++ b/Src/Xeeny/Xeeny.csproj
@@ -11,6 +11,9 @@ It is Cross Platform, Duplex, Multiple Transports, Asynchronous, Typed Proxies, 
     <PackageIconUrl>http://icons.iconarchive.com/icons/kyo-tux/delikate/64/Network-icon.png</PackageIconUrl>
     <PackageTags>C# csharp .net standard dotnetstandard duplex services cross-platform multiple-transport tcp udp framework xamarin</PackageTags>
     <PackageReleaseNotes>first release</PackageReleaseNotes>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
I'm trying to use your library, but the prerelease System.Memory NuGet is causing me a headache. The first commit removes its usage. Every usage of Span.Slice can either be removed directly, or replaced with a GetSubArray function because it was followed by ToArray anyway.

The second commit is a but where the ServiceHost constructor taking a singleton service instance is ignoring the supplied instance and creating a new one down the line.

Third commit updates version numbers (NuGet package and assembly versions) to reflect patch changes.