### PR TITLE
NamedPipe transport implementation

### DIFF
--- a/Src/Xeeny.ConsoleTest/Xeeny.ConsoleTest.csproj
+++ b/Src/Xeeny.ConsoleTest/Xeeny.ConsoleTest.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Xeeny.Extensions.Loggers\Xeeny.Extensions.Loggers.csproj" />
     <ProjectReference Include="..\Xeeny.Http\Xeeny.Http.csproj" />
+    <ProjectReference Include="..\Xeeny.NamedPipes\Xeeny.NamedPipes.csproj" />
     <ProjectReference Include="..\Xeeny.Serialization.JsonSerializer\Xeeny.Serialization.JsonSerializer.csproj" />
     <ProjectReference Include="..\Xeeny.Serialization.ProtobufSerializer\Xeeny.Serialization.ProtobufSerializer.csproj" />
     <ProjectReference Include="..\Xeeny.Sockets\Xeeny.Sockets.csproj" />

--- a/Src/Xeeny.NamedPipes/ApiExtensions/ConnectionBuilderExtensions.cs
+++ b/Src/Xeeny.NamedPipes/ApiExtensions/ConnectionBuilderExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Xeeny.Api.Client;
+using Xeeny.NamedPipes;
+using Xeeny.NamedPipes.ApiExtensions;
+using Xeeny.Transports;
+
+public static class ConnectionBuilderExtensions
+{
+    public static TBuilder WithNamedPipeTransport<TBuilder>(this TBuilder builder, string pipeName, string server,
+        Action<NamedPipeTransportSettings> options = null)
+        where TBuilder : BaseConnectionBuilder
+    {
+        var settings = new NamedPipeTransportSettings(ConnectionSide.Client);
+
+        options?.Invoke(settings);
+
+        builder.TransportFactory = new NamedPipeTransportFactory(pipeName, server, settings);
+
+        return builder;
+    }
+}

--- a/Src/Xeeny.NamedPipes/ApiExtensions/NamedPipeTools.cs
+++ b/Src/Xeeny.NamedPipes/ApiExtensions/NamedPipeTools.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Xeeny.Transports;
+
+namespace Xeeny.NamedPipes.ApiExtensions
+{
+    class NamedPipeTools
+    {
+        public static NamedPipeTransport CreateNamedPipeTransport(string pipeName, string server, NamedPipeTransportSettings settings, ILoggerFactory loggerFactory)
+        {
+            if (string.IsNullOrEmpty(pipeName))
+            {
+                throw new ArgumentNullException(nameof(pipeName));
+            }
+
+            if (string.IsNullOrEmpty(server))
+            {
+                server = ".";
+            }
+
+            return new NamedPipeTransport(pipeName, server, settings, loggerFactory);
+        }
+
+        public static IListener CreateNamedPipeListener(string pipeName, NamedPipeTransportSettings settings, ILoggerFactory loggerFactory)
+        {
+            if (string.IsNullOrEmpty(pipeName))
+            {
+                throw new ArgumentNullException(nameof(pipeName));
+            }
+
+            return new NamedPipeListener(pipeName, settings, loggerFactory);
+        }
+
+        public static void DisposePipe(PipeStream pipe)
+        {
+            if (pipe == null)
+                return;
+            using (var x = pipe)
+                x.Close();
+        }
+
+        public static async Task<byte[]> ReadFromPipe(PipeStream pipe, CancellationToken ct)
+        {
+            byte[] buffer = new byte[255];
+
+            int length = await pipe.ReadAsync(buffer, 0, buffer.Length, ct);
+
+            byte[] chunk = new byte[length];
+
+            Array.Copy(buffer, chunk, length);
+
+            return chunk;
+        }
+
+        public static async Task WriteToPipe(PipeStream pipe, byte[] data, CancellationToken ct)
+        {
+            await pipe.WriteAsync(data, 0, data.Length, ct);
+
+            pipe.WaitForPipeDrain();
+        }
+    }
+}

--- a/Src/Xeeny.NamedPipes/ApiExtensions/NamedPipeTransportFactory.cs
+++ b/Src/Xeeny.NamedPipes/ApiExtensions/NamedPipeTransportFactory.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Logging;
+using Xeeny.Api.Client;
+using Xeeny.Transports;
+
+namespace Xeeny.NamedPipes.ApiExtensions
+{
+    class NamedPipeTransportFactory : ITransportFactory
+    {
+        private readonly NamedPipeTransportSettings _settings;
+        private readonly string _pipeName;
+        private readonly string _server;
+
+        public NamedPipeTransportFactory(string pipeName, string server, NamedPipeTransportSettings settings)
+        {
+            _pipeName = pipeName;
+            _server = server;
+            _settings = settings;
+        }
+
+        public ITransport CreateTransport(ILoggerFactory loggerFactory)
+        {
+            return NamedPipeTools.CreateNamedPipeTransport(_pipeName, _server, _settings, loggerFactory);
+        }
+    }
+}

--- a/Src/Xeeny.NamedPipes/ApiExtensions/ServiceHostBuilderExtensions.cs
+++ b/Src/Xeeny.NamedPipes/ApiExtensions/ServiceHostBuilderExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Xeeny.Api.Server;
+using Xeeny.NamedPipes;
+using Xeeny.NamedPipes.ApiExtensions;
+using Xeeny.Transports;
+
+public static class ServiceHostBuilderExtensions
+{
+    public static TBuilder AddNamedPipeServer<TBuilder>(this TBuilder builder, string pipeName,
+        Action<NamedPipeTransportSettings> options = null)
+        where TBuilder : BaseServiceHostBuilder
+    {
+        var settings = new NamedPipeTransportSettings(ConnectionSide.Server);
+        options?.Invoke(settings);
+        var listener = NamedPipeTools.CreateNamedPipeListener(pipeName, settings, builder.LoggerFactory);
+        builder.Listeners.Add(listener);
+        return builder;
+    }
+}

--- a/Src/Xeeny.NamedPipes/FramingProtocol.cs
+++ b/Src/Xeeny.NamedPipes/FramingProtocol.cs
@@ -1,0 +1,16 @@
+﻿namespace Xeeny.NamedPipes
+{
+    public enum FramingProtocol
+    {
+        /// <summary>
+        /// If messages are fragmented (SendBufferSize is smaller than message) this option will send message parts in serial way, any concurrent method calls will be pending until current call completes 
+        /// <para>Server and Client should have same FramingProtocol</para>
+        /// </summary>
+        SerialFragments,
+        /// <summary>
+        /// If messages are fragmented (SendBufferSize is smaller than message) this option will send message parts in concurrent way, concurrent method calls can interleave
+        /// <para>Server and Client should have same FramingProtocol</para>
+        /// </summary>
+        ConcurrentFragments
+    }
+}

--- a/Src/Xeeny.NamedPipes/NamedPipeChannel.cs
+++ b/Src/Xeeny.NamedPipes/NamedPipeChannel.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xeeny.NamedPipes.ApiExtensions;
+using Xeeny.Transports;
+using Xeeny.Transports.Channels;
+
+namespace Xeeny.NamedPipes
+{
+    class NamedPipeChannel : ITransportChannel
+    {
+        public string ConnectionName => _connectionName;
+        public ConnectionSide ConnectionSide => _connectionSide;
+
+        private readonly string _pipeName;
+        private readonly string _server;
+        private readonly ConnectionSide _connectionSide;
+        private readonly string _connectionName;
+        private readonly string _connectionId;
+
+        private PipeStream _pipeStream;
+
+        public NamedPipeChannel(NamedPipeServerStream serverStream, string connectionName)
+        {
+            _pipeStream = serverStream;
+            _connectionName = connectionName;
+            _connectionSide = ConnectionSide.Server;
+        }
+
+        public NamedPipeChannel(string pipeName, string server, string connectionName, string connectionId)
+        {
+            _pipeName = pipeName;
+            _server = server;
+            _connectionName = connectionName;
+            _connectionId = connectionId.Replace("-", "");
+            _connectionSide = ConnectionSide.Client;
+        }
+
+        public async Task Connect(CancellationToken ct)
+        {
+            if (_connectionSide == ConnectionSide.Client)
+            {
+                var dataPipeName = GenerateDataPipeName(_pipeName);
+
+                using (var handshakePipe = NamedPipeClientStreamFactory.CreatePipe(_pipeName, _server))
+                {
+                    await handshakePipe.ConnectAsync(ct).ConfigureAwait(false);
+
+                    await NamedPipeTools.WriteToPipe(handshakePipe, Encoding.UTF8.GetBytes(dataPipeName), ct);
+
+                    handshakePipe.Close();
+                }
+
+                var dataPipe = NamedPipeClientStreamFactory.CreatePipe(dataPipeName, _server);
+
+                await dataPipe.ConnectAsync(ct);
+
+                _pipeStream = dataPipe;
+            }
+        }
+
+        public async Task SendAsync(ArraySegment<byte> segment, CancellationToken ct)
+        {
+            await _pipeStream.WriteAsync(segment.Array, segment.Offset, segment.Count, ct).ConfigureAwait(false);
+
+            _pipeStream.WaitForPipeDrain();
+        }
+
+        public async Task<int> ReceiveAsync(ArraySegment<byte> segment, CancellationToken ct)
+        {
+            var result = await _pipeStream.ReadAsync(segment.Array, segment.Offset, segment.Count, ct).ConfigureAwait(false);
+
+            return result;
+        }
+
+        public Task Close(CancellationToken ct)
+        {
+            try
+            {
+                NamedPipeTools.DisposePipe(_pipeStream);
+            }
+            catch
+            {
+                //
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private string GenerateDataPipeName(string pipeName)
+        {
+            return $"{pipeName}_{_connectionId}";
+        }
+    }
+}

--- a/Src/Xeeny.NamedPipes/NamedPipeClientStreamFactory.cs
+++ b/Src/Xeeny.NamedPipes/NamedPipeClientStreamFactory.cs
@@ -1,0 +1,12 @@
+﻿using System.IO.Pipes;
+
+namespace Xeeny.NamedPipes
+{
+    static class NamedPipeClientStreamFactory
+    {
+        public static NamedPipeClientStream CreatePipe(string pipeName, string serverName)
+        {
+            return new NamedPipeClientStream(serverName, pipeName, PipeDirection.InOut, PipeOptions.Asynchronous | PipeOptions.WriteThrough);
+        }
+    }
+}

--- a/Src/Xeeny.NamedPipes/NamedPipeListener.cs
+++ b/Src/Xeeny.NamedPipes/NamedPipeListener.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Xeeny.NamedPipes.ApiExtensions;
+using Xeeny.Transports;
+
+namespace Xeeny.NamedPipes
+{
+    public class NamedPipeListener : IListener
+    {
+        private readonly NamedPipeTransportSettings _pipeSettings;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ILogger _logger;
+        private readonly string _pipeName;
+        private readonly CancellationTokenSource _tokenSource;
+
+        public NamedPipeListener(string pipeName, NamedPipeTransportSettings settings, ILoggerFactory loggerFactory)
+        {
+            _pipeName = pipeName;
+            _pipeSettings = settings;
+            _loggerFactory = loggerFactory;
+            _logger = _loggerFactory.CreateLogger(nameof(NamedPipeListener));
+            _tokenSource = new CancellationTokenSource();
+        }
+
+        public void Listen()
+        {
+            // nothing to do
+        }
+
+        public async Task<ITransport> AcceptConnection()
+        {
+            NamedPipeServerStream dataPipe = null;
+
+            try
+            {
+                string dataPipeName = await Handshake();
+
+                dataPipe = NamedPipeServerStreamFactory.CreatePipe(dataPipeName, _pipeSettings.MaxNumberOfServerInstances);
+
+                await dataPipe.WaitForConnectionAsync(_tokenSource.Token);
+
+                return new NamedPipeTransport(dataPipe, _pipeSettings, _loggerFactory);
+
+            }
+            catch (Exception)
+            {
+                NamedPipeTools.DisposePipe(dataPipe);
+
+                throw;
+            }
+        }
+
+        private async Task<string> Handshake()
+        {
+            using (NamedPipeServerStream handshakePipe = NamedPipeServerStreamFactory.CreatePipe(_pipeName))
+            {
+                try
+                {
+                    await handshakePipe.WaitForConnectionAsync(_tokenSource.Token);
+
+                    var dataPipeNameData = await NamedPipeTools.ReadFromPipe(handshakePipe, _tokenSource.Token);
+
+                    return Encoding.UTF8.GetString(dataPipeNameData);
+                }
+                finally
+                {
+                    handshakePipe.Close();
+                }
+            }
+        }
+
+        public void Close()
+        {
+            _tokenSource.Cancel();
+        }
+    }
+}
+

--- a/Src/Xeeny.NamedPipes/NamedPipeServerStreamFactory.cs
+++ b/Src/Xeeny.NamedPipes/NamedPipeServerStreamFactory.cs
@@ -1,0 +1,12 @@
+﻿using System.IO.Pipes;
+
+namespace Xeeny.NamedPipes
+{
+    static class NamedPipeServerStreamFactory
+    {
+        public static NamedPipeServerStream CreatePipe(string pipeName, int maxNumberOfServerInstance = 1)
+        {
+            return new NamedPipeServerStream(pipeName, PipeDirection.InOut, maxNumberOfServerInstance, PipeTransmissionMode.Byte, PipeOptions.Asynchronous | PipeOptions.WriteThrough, 0, 0);
+        }
+    }
+}

--- a/Src/Xeeny.NamedPipes/NamedPipeTransport.cs
+++ b/Src/Xeeny.NamedPipes/NamedPipeTransport.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Xeeny.Transports;
+using Xeeny.Transports.Channels;
+
+namespace Xeeny.NamedPipes
+{
+    class NamedPipeTransport : TransportBase
+    {
+        readonly IMessageChannel _channel;
+
+        public NamedPipeTransport(NamedPipeServerStream pipeStream, NamedPipeTransportSettings settings, ILoggerFactory loggerFactory)
+            : base(settings, ConnectionSide.Server, loggerFactory.CreateLogger(nameof(NamedPipeTransport)))
+        {
+            var transport = new NamedPipeChannel(pipeStream, this.ConnectionName);
+            _channel = CreateChannel(transport, settings);
+        }
+
+        public NamedPipeTransport(string pipeName, string server, NamedPipeTransportSettings settings, ILoggerFactory loggerFactory)
+            : base(settings, ConnectionSide.Client, loggerFactory.CreateLogger(nameof(NamedPipeTransport)))
+        {
+            var transport = new NamedPipeChannel(pipeName, server, this.ConnectionName, this.ConnectionId);
+            _channel = CreateChannel(transport, settings);
+        }
+
+        IMessageChannel CreateChannel(ITransportChannel transport, NamedPipeTransportSettings settings)
+        {
+            var framing = settings.FramingProtocol;
+            switch (framing)
+            {
+                case FramingProtocol.SerialFragments: return new SerialMessageStreamChannel(transport, settings);
+                case FramingProtocol.ConcurrentFragments: return new ConcurrentMessageStreamChannel(transport, settings);
+                default: throw new NotSupportedException(framing.ToString());
+            }
+        }
+
+        protected override Task OnConnect(CancellationToken ct)
+        {
+            return _channel.Connect(ct);
+        }
+
+        protected override Task SendMessage(Message message, CancellationToken ct)
+        {
+            return _channel.SendMessage(message, ct);
+        }
+
+        protected override Task<Message> ReceiveMessage(CancellationToken ct)
+        {
+            return _channel.ReceiveMessage(ct);
+        }
+
+        protected override Task OnClose(CancellationToken ct)
+        {
+            return _channel.Close(ct);
+        }
+
+        protected override void OnKeepAlivedReceived(Message message)
+        {
+            //nothing
+        }
+
+        protected override void OnAgreementReceived(Message message)
+        {
+            //nothing
+        }
+    }
+}

--- a/Src/Xeeny.NamedPipes/NamedPipeTransportSettings.cs
+++ b/Src/Xeeny.NamedPipes/NamedPipeTransportSettings.cs
@@ -1,0 +1,20 @@
+﻿using Xeeny.Transports;
+
+namespace Xeeny.NamedPipes
+{
+    public class NamedPipeTransportSettings : TransportSettings
+    {
+        /// <summary>
+        /// Message Framing Protocol
+        /// </summary>
+        public FramingProtocol FramingProtocol { get; set; }
+
+        public int MaxNumberOfServerInstances { get; set; }
+
+        public NamedPipeTransportSettings(ConnectionSide connectionSide) : base(connectionSide)
+        {
+            MaxNumberOfServerInstances = 1;
+            FramingProtocol = FramingProtocol.SerialFragments;
+        }
+    }
+}

--- a/Src/Xeeny.NamedPipes/Xeeny.NamedPipes.csproj
+++ b/Src/Xeeny.NamedPipes/Xeeny.NamedPipes.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Mohamad Alallan</Authors>
+    <Company></Company>
+    <Description>
+      NamedPipe for Xeeny, A framework for building and consuming services on devices and servers that support .net standard.
+      It is Cross Platform, Duplex, Multiple Transports, Asynchronous, Typed Proxies, Configurable, and Extendable
+    </Description>
+    <PackageLicenseUrl>https://github.com/MhAllan/Xeeny/blob/develop/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/MhAllan/Xeeny</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/MhAllan/Xeeny/develop/nuget-logo.png</PackageIconUrl>
+    <PackageTags>C# csharp .net standard dotnetstandard duplex services cross-platform multiple-transport tcp udp framework xamarin</PackageTags>
+    <PackageReleaseNotes>internal updates</PackageReleaseNotes>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Xeeny.Transports\Xeeny.Transports.csproj" />
+    <ProjectReference Include="..\Xeeny\Xeeny.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Src/Xeeny.sln
+++ b/Src/Xeeny.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xeeny.Transports", "Xeeny.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xeeny.Http", "Xeeny.Http\Xeeny.Http.csproj", "{B50B2B78-1045-4915-826E-23D6C6BB3C3F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xeeny.NamedPipes", "Xeeny.NamedPipes\Xeeny.NamedPipes.csproj", "{E556D5B9-D4EE-491A-A86F-86D05F4D75BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{B50B2B78-1045-4915-826E-23D6C6BB3C3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B50B2B78-1045-4915-826E-23D6C6BB3C3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B50B2B78-1045-4915-826E-23D6C6BB3C3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E556D5B9-D4EE-491A-A86F-86D05F4D75BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E556D5B9-D4EE-491A-A86F-86D05F4D75BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E556D5B9-D4EE-491A-A86F-86D05F4D75BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E556D5B9-D4EE-491A-A86F-86D05F4D75BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -88,6 +94,7 @@ Global
 		{B3B1FB13-86F6-4AD9-9FF2-7B19A3D71B9F} = {410A6F61-9AE0-4A08-BE1E-B45008DD78A7}
 		{73FF9275-0D8C-4EE5-818F-C3DC732C8B8E} = {E311F5F6-0C78-4859-A5D9-948ADC3208D2}
 		{B50B2B78-1045-4915-826E-23D6C6BB3C3F} = {E311F5F6-0C78-4859-A5D9-948ADC3208D2}
+		{E556D5B9-D4EE-491A-A86F-86D05F4D75BD} = {E311F5F6-0C78-4859-A5D9-948ADC3208D2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C83B20B6-D44D-448C-B815-8DCEFC0ABB54}

--- a/Src/Xeeny/AssemblyInfo.cs
+++ b/Src/Xeeny/AssemblyInfo.cs
@@ -4,3 +4,4 @@
 [assembly: InternalsVisibleTo("Xeeny.Serialization.JsonSerializer")]
 [assembly: InternalsVisibleTo("Xeeny.Serialization.ProtobufSerializer")]
 [assembly: InternalsVisibleTo("Xeeny.Http")]
+[assembly: InternalsVisibleTo("Xeeny.NamedPipes")]


### PR DESCRIPTION
Hi,

First nice library, missing those DI to make it perfect.

Here is named pipe implementation, it was a bit tricky because of IListener and AcceptConnection and how the named pipe is working, but manage to get it sorted by using handshake logic, there was few examples on net, where client is connecting to server pipe, writing it's connection id, and with that id server pipe is created for client (data pipe => Transport => Channel)

i could reverse this so the server is generating pipe name for transport and sending it to client to connect, but i used the connection id from client which is for now more logical, 1 to 1, this could be extended to create auto reconnect etc...